### PR TITLE
lower case root label

### DIFF
--- a/hazm/dependency_parser.py
+++ b/hazm/dependency_parser.py
@@ -133,7 +133,7 @@ class MaltParser(NLTKMaltParser):
                 raise Exception("MaltParser parsing failed: %s" % " ".join(cmd))
 
             return (
-                DependencyGraph(item)
+                DependencyGraph(item, top_relation_label='root')
                 for item in open(output_file.name, encoding="utf8").read().split("\n\n") # noqa: SIM115, PTH123
                 if item.strip()
             )


### PR DESCRIPTION
it seems maltParser writes "root" instead of "ROOT" in output file and this causes error in later
this will fix #327 