### PR TITLE
تغییر مقولات درشت

### DIFF
--- a/hazm/corpus_readers/bijankhan_reader.py
+++ b/hazm/corpus_readers/bijankhan_reader.py
@@ -38,7 +38,7 @@ default_pos_map = {
     "DEFAULT": "DEFAULT",
     "DELM": "PUNC",
     "DET": "DET",
-    "IF": "IF",
+    "IF": "CONJ",
     "INT": "INT",
     "MORP": "MORP",
     "MQUA": "ADV",

--- a/hazm/corpus_readers/bijankhan_reader.py
+++ b/hazm/corpus_readers/bijankhan_reader.py
@@ -53,7 +53,7 @@ default_pos_map = {
     "PP": "PP",
     "PRO": "PR",
     "PS": "PS",
-    "QUA": "QUA",
+    "QUA": "DET",
     "SPEC": "SPEC",
     "V_AUX": "V",
     "V_IMP": "V",

--- a/hazm/corpus_readers/bijankhan_reader.py
+++ b/hazm/corpus_readers/bijankhan_reader.py
@@ -48,7 +48,7 @@ default_pos_map = {
     "NN": "NN",
     "NP": "NP",
     "OH": "OH",
-    "OHH": "OHH",
+    "OHH": "N",
     "P": "PREP",
     "PP": "PP",
     "PRO": "PR",

--- a/hazm/corpus_readers/bijankhan_reader.py
+++ b/hazm/corpus_readers/bijankhan_reader.py
@@ -41,7 +41,7 @@ default_pos_map = {
     "IF": "IF",
     "INT": "INT",
     "MORP": "MORP",
-    "MQUA": "MQUA",
+    "MQUA": "ADV",
     "MS": "MS",
     "N_PL": "N",
     "N_SING": "N",

--- a/hazm/corpus_readers/bijankhan_reader.py
+++ b/hazm/corpus_readers/bijankhan_reader.py
@@ -37,7 +37,7 @@ default_pos_map = {
     "CON": "CONJ",
     "DEFAULT": "DEFAULT",
     "DELM": "PUNC",
-    "DET": "PREP",
+    "DET": "DET",
     "IF": "IF",
     "INT": "INT",
     "MORP": "MORP",

--- a/hazm/corpus_readers/bijankhan_reader.py
+++ b/hazm/corpus_readers/bijankhan_reader.py
@@ -23,7 +23,7 @@ from .peykare_reader import join_verb_parts
 default_pos_map = {
     "ADJ": "ADJ",
     "ADJ_CMPR": "ADJ",
-    "ADJ_INO": "ADJ",
+    "ADJ_INO": "V",
     "ADJ_ORD": "ADJ",
     "ADJ_SIM": "ADJ",
     "ADJ_SUP": "ADJ",


### PR DESCRIPTION
تعریفگرها (determiner) به اشتباه به حرف اضافه نگاشت شده بودند

تگ ADJ_INO به اشتباه به صفت تبدیل شده که به فعل تغییر کرد

تگ IF (ادات شرط) اگر به مقوله درشت بخواهد تبدیل شود، باید به حروف پیوندی تبدیل شود

تگ MQUA قید است

تگ OHH منادی است که منادی‌ها اسم هستند

تگ QUA به کمیت‌نماها که ذیل تعریفگرها هستند تعلق دارد